### PR TITLE
Add CountDocuments method with soft delete support in middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+## [v0.1.2] - 2025-09-25
+
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),  
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [v0.1.2] - 2024-06-xx
+
+### 🚀 Features
+- **Count API**: Added support for counting documents with a soft delete filter (`feat(count): ✨ add count documents with soft delete filter`)
+
+### 🛠 Chore
+- Updated module path for consistency and maintainability (`chore(module): 🔧 update module path`)
+
+---
+
+### 🔑 Relevant Commits
+- `feat(count): ✨ add count documents with soft delete filter`
+- `chore(module): 🔧 update module path`
+
+
+# Changelog
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+

--- a/go_mongo_soft_delete.go
+++ b/go_mongo_soft_delete.go
@@ -37,6 +37,7 @@ type ISoftDeleteMiddleware interface {
 	FindOneAndUpdate(ctx context.Context, filter interface{}, update interface{}, opts ...*options.FindOneAndUpdateOptions) *mongo.SingleResult
 	InsertOne(ctx context.Context, create interface{}, opts ...*options.InsertOneOptions) (*mongo.InsertOneResult, error)
 	InsertMany(ctx context.Context, creates []interface{}, opts ...*options.InsertManyOptions) (*mongo.InsertManyResult, error)
+	CountDocuments(ctx context.Context, filter interface{}, opts ...*options.CountOptions) (int64, error)
 
 	Indexes() mongo.IndexView
 }
@@ -55,6 +56,12 @@ func (m *SoftDeleteMiddleware) Find(ctx context.Context, filter interface{}, opt
 func (m *SoftDeleteMiddleware) FindOne(ctx context.Context, filter interface{}, opts ...*options.FindOneOptions) *mongo.SingleResult {
 	filter = m.addSoftDeleteFilter(filter)
 	return m.Collection.FindOne(ctx, filter, opts...)
+}
+
+// CountDocuments adds a soft delete filter to the query. It ensures that only documents with deleted=false are returned.
+func (m *SoftDeleteMiddleware) CountDocuments(ctx context.Context, filter interface{}, opts ...*options.CountOptions) (int64, error) {
+	filter = m.addSoftDeleteFilter(filter)
+	return m.Collection.CountDocuments(ctx, filter, opts...)
 }
 
 // SoftDeleteOne performs a soft delete operation


### PR DESCRIPTION

---

### Description

This PR adds a `CountDocuments` method to the `SoftDeleteMiddleware` in order to provide consistent filtering for soft-deleted documents when counting documents.  

Specifically:  
- The `ISoftDeleteMiddleware` interface now includes a `CountDocuments` method.  
- Implemented `CountDocuments` in `SoftDeleteMiddleware` to automatically append the soft delete filter, ensuring only non-deleted documents are counted.  
- Added inline GoDoc comment for clarity about the behavior of `CountDocuments`.  

---

### Related Issue  
Jira Issue (Optional): *Not provided*  

---

### Type of Change  
- [x] New feature (non-breaking change which adds functionality)  
- [ ] Bug fix (non-breaking change which fixes an issue)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update  

---

### How Has This Been Tested?  
- Added method implementation – unit tests for `CountDocuments` should be added/extended to verify:  
  - Counts only documents with `deleted=false`.  
  - Respects additional filters passed in by the caller.  
  - Works correctly with `options.CountOptions`.  

*No new tests were included in this diff; follow-up may be required to ensure coverage.*  

---

### Checklist  
- [x] Code follows the project’s coding standards  
- [x] Changes are self-contained and do not introduce side effects  
- [x] Proper comments have been added for clarity  
- [ ] Tests have been added or updated to cover the changes (pending)  
- [ ] Documentation has been updated if necessary  

---

### Review Notes
- 👍 Good addition: The `CountDocuments` method aligns with the pattern used in `Find`, `FindOne`, etc., maintaining soft delete consistency across operations.  
- ⚠️ A gap: No tests were included in this PR. Testing should ensure the soft delete logic is respected for counts.  
- 📝 Suggestion: It may be useful to add integration tests against MongoDB with sample data for confidence.  

**Overall**: Solid, non-breaking feature addition. The code is clean, consistent, and follows the existing middleware design. The primary recommendation is to add test coverage before merge.